### PR TITLE
Fix cmake files hardcoded library path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ export(
 	FILE "${CMAKE_CURRENT_BINARY_DIR}/emcrk-config-targets.cmake"
 )
 
-set(ConfigPackageLocation lib/cmake/emcrk)
+set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/emcrk)
 configure_package_config_file(cmake/emcrk-config.cmake.in
 	"${CMAKE_CURRENT_BINARY_DIR}/emcrk-config.cmake"
 	INSTALL_DESTINATION ${ConfigPackageLocation}


### PR DESCRIPTION
Ścieżka dla plików cmake jest zapisana na "sztywno" przez co na systemach 64 bitowych jest umieszczana w nie prawidłowym katalogu /usr/lib/cmake zamiast /usr/lib64/cmake